### PR TITLE
fix: missing provider in options of releaser

### DIFF
--- a/cmd/publish.go
+++ b/cmd/publish.go
@@ -70,9 +70,10 @@ var publishCmd = &cobra.Command{
 			split := strings.Split(viper.GetString("GITHUB_REPOSITORY"), "/")
 
 			options := releaser.Options{
-				Token: viper.GetString("GITHUB_TOKEN"),
-				Owner: split[0],
-				Repo:  split[1],
+				Token:    viper.GetString("GITHUB_TOKEN"),
+				Owner:    split[0],
+				Repo:     split[1],
+				Provider: "github",
 			}
 			releaseService = releaser.CreateReleaser(options)
 		}


### PR DESCRIPTION
- would cause panic as release notary cannot run without specifying the provider