### PR TITLE
fix: new lines in ReleaseNotes

### DIFF
--- a/internal/text/release_notes.go
+++ b/internal/text/release_notes.go
@@ -5,6 +5,8 @@ import "strings"
 // ReleaseNotes generates the output mentioned in the expected-output.md
 func ReleaseNotes(sections Sections) string {
 	builder := strings.Builder{}
+	// Extra lines at the start to make sure formatting starts correctly
+	builder.WriteString("\n\n")
 
 	builder.WriteString(buildSection("features", sections.Features))
 

--- a/internal/text/release_notes_test.go
+++ b/internal/text/release_notes_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestReleaseNotes(t *testing.T) {
-	expected := "## Features :rocket:\n\n- ci test\n\n## Bug fixes :bug:\n\n- huge bug\n\n## Chores and Improvements :wrench:\n\n- testing\n- this should end up in chores\n\n## Other :package:\n\n- merge master in something\n- random\n\n"
+	expected := "\n\n## Features :rocket:\n\n- ci test\n\n## Bug fixes :bug:\n\n- huge bug\n\n## Chores and Improvements :wrench:\n\n- testing\n- this should end up in chores\n\n## Other :package:\n\n- merge master in something\n- random\n\n"
 
 	sections := Sections{
 		Features: []string{"ci test"},


### PR DESCRIPTION
- without these new lines formatting would start incorrectly