### PR TITLE
chores: use text.Commit in log and build history

### DIFF
--- a/cmd/log.go
+++ b/cmd/log.go
@@ -46,7 +46,7 @@ var logCmd = &cobra.Command{
 			return err
 		}
 
-		var commitMessages []string
+		var parsedCommits []text.Commit
 
 		for _, commit := range commits {
 			commitObject, err := repo.Commit(commit)
@@ -55,12 +55,12 @@ var logCmd = &cobra.Command{
 				return err
 			}
 
-			commitMessages = append(commitMessages,
-				text.TrimMessage(commitObject.Message),
+			parsedCommits = append(parsedCommits,
+				text.ParseCommitMessage(commitObject.Message),
 			)
 		}
 
-		log.Println(text.BuildHistory(commitMessages))
+		log.Println(text.BuildHistory(parsedCommits))
 
 		return nil
 	},

--- a/internal/text/build_history.go
+++ b/internal/text/build_history.go
@@ -5,13 +5,15 @@ import (
 )
 
 // BuildHistory takes commit messages and builds a complete list
-func BuildHistory(messages []string) string {
+func BuildHistory(messages []Commit) string {
 	builder := strings.Builder{}
 	builder.WriteString("\n")
 
 	for i := 0; i < len(messages); i++ {
 		builder.WriteString("- ")
-		builder.WriteString(messages[i])
+		builder.WriteString(messages[i].Category)
+		builder.WriteString("   ")
+		builder.WriteString(messages[i].Heading)
 		builder.WriteString("\n")
 	}
 


### PR DESCRIPTION
- unifies approach to handling Commits