### PR TITLE
fix(github): squash commits done by github broken

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ testdata/*
 !testdata/*.bundle
 !testdata/setup_test_repos.sh
 .idea
+testrepo

--- a/internal/text/build_history.go
+++ b/internal/text/build_history.go
@@ -15,7 +15,7 @@ func BuildHistory(messages []quoad.Commit) string {
 		builder.WriteString("- ")
 		builder.WriteString(messages[i].Category)
 		builder.WriteString("   ")
-		builder.WriteString(messages[i].Heading)
+		builder.WriteString(TrimMessage(messages[i].Heading))
 		builder.WriteString("\n")
 	}
 

--- a/internal/text/build_single_commit.go
+++ b/internal/text/build_single_commit.go
@@ -38,7 +38,7 @@ func buildSimpleCommit(commit quoad.Commit) string {
 		builder.WriteString(" ")
 	}
 
-	builder.WriteString(commit.Heading)
+	builder.WriteString(TrimMessage(commit.Heading))
 
 	for _, refID := range commit.Issues {
 		builder.WriteString(fmt.Sprintf(" #%d", refID))
@@ -60,7 +60,7 @@ func buildFullCommit(commit quoad.Commit, open bool) string {
 	builder.WriteString("<summary>")
 	builder.WriteString(commit.Hash.String()[:7])
 	builder.WriteString(" ")
-	builder.WriteString(commit.Heading)
+	builder.WriteString(TrimMessage(commit.Heading))
 	builder.WriteString("</summary>")
 	builder.WriteString("\n\n")
 	builder.WriteString(commit.Body)

--- a/internal/text/release_notes_test.go
+++ b/internal/text/release_notes_test.go
@@ -24,10 +24,10 @@ func TestReleaseNotes(t *testing.T) {
 	expected := string(b)
 
 	sections := map[string][]quoad.Commit{
-		"features": []quoad.Commit{quoad.Commit{Category: "feat", Scope: "ci", Heading: "ci test", Body: "- Body"}},
-		"chores":   []quoad.Commit{quoad.Commit{Category: "chore", Scope: "", Heading: "testing", Body: "- Body"}, quoad.Commit{Category: "improvement", Scope: "", Heading: "this should end up in chores", Issues: []int{12}}},
-		"bugs":     []quoad.Commit{quoad.Commit{Category: "bug", Scope: "", Heading: "huge bug", Body: "Body"}},
-		"others":   []quoad.Commit{quoad.Commit{Category: "other", Scope: "", Heading: "merge master in something"}, quoad.Commit{Category: "bs", Scope: "", Heading: "random"}},
+		"features": {quoad.Commit{Category: "feat", Scope: "ci", Heading: "ci test", Body: "- Body"}},
+		"chores":   {quoad.Commit{Category: "chore", Scope: "", Heading: "testing", Body: "- Body"}, quoad.Commit{Category: "improvement", Scope: "", Heading: "this should end up in chores", Issues: []int{12}}},
+		"bugs":     {quoad.Commit{Category: "bug", Scope: "", Heading: "huge bug", Body: "Body"}},
+		"others":   {quoad.Commit{Category: "other", Scope: "", Heading: "merge master in something"}, quoad.Commit{Category: "bs", Scope: "", Heading: "random"}},
 	}
 
 	releaseNotes := notes.Generate(sections, false)
@@ -50,10 +50,10 @@ func TestReleaseNotesSimple(t *testing.T) {
 	expected := string(b)
 
 	sections := map[string][]quoad.Commit{
-		"features": []quoad.Commit{quoad.Commit{Category: "feat", Scope: "ci", Heading: "ci test"}},
-		"chores":   []quoad.Commit{quoad.Commit{Category: "chore", Scope: "", Heading: "testing"}, quoad.Commit{Category: "improvement", Scope: "", Heading: "this should end up in chores", Issues: []int{12}}},
-		"bugs":     []quoad.Commit{quoad.Commit{Category: "bug", Scope: "", Heading: "huge bug"}},
-		"others":   []quoad.Commit{quoad.Commit{Category: "other", Scope: "", Heading: "merge master in something"}, quoad.Commit{Category: "bs", Scope: "", Heading: "random"}},
+		"features": {quoad.Commit{Category: "feat", Scope: "ci", Heading: "ci test"}},
+		"chores":   {quoad.Commit{Category: "chore", Scope: "", Heading: "testing"}, quoad.Commit{Category: "improvement", Scope: "", Heading: "this should end up in chores", Issues: []int{12}}},
+		"bugs":     {quoad.Commit{Category: "bug", Scope: "", Heading: "huge bug"}},
+		"others":   {quoad.Commit{Category: "other", Scope: "", Heading: "merge master in something"}, quoad.Commit{Category: "bs", Scope: "", Heading: "random"}},
 	}
 
 	releaseNotes := notes.Generate(sections, false)
@@ -66,7 +66,7 @@ func TestReleaseNotesWithMissingSections(t *testing.T) {
 	expected := "\n\n## :rocket: Features\n\n- 0000000 ci test\n\n"
 
 	sections := map[string][]quoad.Commit{
-		"features": []quoad.Commit{quoad.Commit{Heading: "ci test"}},
+		"features": {quoad.Commit{Heading: "ci test"}},
 	}
 
 	releaseNotes := notes.Generate(sections, false)

--- a/internal/text/split_sections_test.go
+++ b/internal/text/split_sections_test.go
@@ -9,20 +9,20 @@ import (
 
 func TestSplitSections(t *testing.T) {
 	dataset := []quoad.Commit{
-		quoad.Commit{Category: "chore", Scope: "", Heading: "testing"},
-		quoad.Commit{Category: "feat", Scope: "ci", Heading: "ci test"},
-		quoad.Commit{Category: "other", Scope: "", Heading: "merge master in something"},
-		quoad.Commit{Category: "bs", Scope: "", Heading: "random"},
-		quoad.Commit{Category: "improvement", Scope: "", Heading: "this should end up in chores"},
-		quoad.Commit{Category: "bug", Scope: "", Heading: "huge bug"},
-		quoad.Commit{Category: "fix", Scope: "", Heading: "bug fix"},
+		{Category: "chore", Scope: "", Heading: "testing"},
+		{Category: "feat", Scope: "ci", Heading: "ci test"},
+		{Category: "other", Scope: "", Heading: "merge master in something"},
+		{Category: "bs", Scope: "", Heading: "random"},
+		{Category: "improvement", Scope: "", Heading: "this should end up in chores"},
+		{Category: "bug", Scope: "", Heading: "huge bug"},
+		{Category: "fix", Scope: "", Heading: "bug fix"},
 	}
 
 	expected := map[string][]quoad.Commit{
-		"features": []quoad.Commit{quoad.Commit{Category: "feat", Scope: "ci", Heading: "ci test"}},
-		"chores":   []quoad.Commit{quoad.Commit{Category: "chore", Scope: "", Heading: "testing"}, quoad.Commit{Category: "improvement", Scope: "", Heading: "this should end up in chores"}},
-		"bugs":     []quoad.Commit{quoad.Commit{Category: "bug", Scope: "", Heading: "huge bug"}, quoad.Commit{Category: "fix", Scope: "", Heading: "bug fix"}},
-		"others":   []quoad.Commit{quoad.Commit{Category: "other", Scope: "", Heading: "merge master in something"}, quoad.Commit{Category: "bs", Scope: "", Heading: "random"}},
+		"features": {quoad.Commit{Category: "feat", Scope: "ci", Heading: "ci test"}},
+		"chores":   {quoad.Commit{Category: "chore", Scope: "", Heading: "testing"}, quoad.Commit{Category: "improvement", Scope: "", Heading: "this should end up in chores"}},
+		"bugs":     {quoad.Commit{Category: "bug", Scope: "", Heading: "huge bug"}, quoad.Commit{Category: "fix", Scope: "", Heading: "bug fix"}},
+		"others":   {quoad.Commit{Category: "other", Scope: "", Heading: "merge master in something"}, quoad.Commit{Category: "bs", Scope: "", Heading: "random"}},
 	}
 
 	sections := SplitSections(dataset)

--- a/internal/text/trim_message.go
+++ b/internal/text/trim_message.go
@@ -1,17 +1,14 @@
 package text
 
 import (
-	"regexp"
 	"strings"
 )
 
-var messageRegex = regexp.MustCompile("^.*\n")
-
 // TrimMessage returns only the first line of commit message
 func TrimMessage(message string) string {
-	match := messageRegex.FindString(message)
+	match := strings.Split(message, "\n")
 
-	match = strings.Replace(match, "\n", "", 1)
+	final := strings.TrimRight(match[0], " ")
 
-	return match
+	return final
 }

--- a/internal/text/trim_message_test.go
+++ b/internal/text/trim_message_test.go
@@ -1,0 +1,21 @@
+package text
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTrimMessage(t *testing.T) {
+	testset := map[string]string{
+		"ci: sometest \n": "ci: sometest",
+		"ci: sometest\n":  "ci: sometest",
+		"chore: some github message\n some more text here": "chore: some github message",
+		"chore: someother thing":                           "chore: someother thing",
+	}
+
+	for input, expected := range testset {
+		assert.Equal(t, expected, TrimMessage(input))
+	}
+
+}

--- a/internal/text/urls_test.go
+++ b/internal/text/urls_test.go
@@ -7,13 +7,13 @@ import (
 )
 
 type urlTestStruct struct {
-	url string
+	url    string
 	commit string
 }
 
 func TestLinkToCommit(t *testing.T) {
 	tests := map[string]urlTestStruct{
-		"https://github.com/commisar-app/commitsar/commit/12345": urlTestStruct{url: "https://github.com/commisar-app/commitsar", commit:"12345"},
+		"https://github.com/commisar-app/commitsar/commit/12345": {url: "https://github.com/commisar-app/commitsar", commit: "12345"},
 	}
 
 	for expected, test := range tests {


### PR DESCRIPTION
The way github auto squash formats messages would break the relase notes.

Closes #299