### PR TITLE
fix(GitLab): Named release

### DIFF
--- a/internal/gitlab/publish_test.go
+++ b/internal/gitlab/publish_test.go
@@ -26,7 +26,7 @@ func TestPublishExistingRelease(t *testing.T) {
 
 		assert.NoError(t, err)
 
-		expectedBody := fmt.Sprintf("{\"name\":\"\",\"tag_name\":\"%v\",\"description\":\"%v\"}", tagName, newReleaseNotes)
+		expectedBody := fmt.Sprintf("{\"tag_name\":\"%v\",\"description\":\"%v\"}", tagName, newReleaseNotes)
 
 		assert.Equal(t, expectedBody, string(body))
 
@@ -64,7 +64,7 @@ func TestPublishNewRelease(t *testing.T) {
 
 		assert.NoError(t, err)
 
-		expectedBody := fmt.Sprintf("{\"name\":\"\",\"tag_name\":\"%v\",\"description\":\"%v\"}", tagName, newReleaseNotes)
+		expectedBody := fmt.Sprintf("{\"tag_name\":\"%v\",\"description\":\"%v\"}", tagName, newReleaseNotes)
 
 		assert.Equal(t, expectedBody, string(body))
 

--- a/internal/gitlab/service.go
+++ b/internal/gitlab/service.go
@@ -14,7 +14,6 @@ type Gitlab struct {
 }
 
 type gitlabRelease struct {
-	Name    string `json:"name"`
 	TagName string `json:"tag_name"`
 	Message string `json:"description"`
 }


### PR DESCRIPTION
Remove legacy unused name field
Fixes https://github.com/aevea/release-notary/issues/308